### PR TITLE
Added validation for  null input on  store mutations count value

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -31,7 +31,7 @@ export default new Vuex.Store({
   },
   mutations: {
     INCREMENT_COUNT(state, value) {
-      state.count += value
+      value ? (state.count += value) : state.count
     }
   },
   actions: {},


### PR DESCRIPTION
This is a null validation in store state count when the user is trying to increase the input value from MutationSample.vue view and the input field is empty 